### PR TITLE
Syntax simplification

### DIFF
--- a/initial-checks.k
+++ b/initial-checks.k
@@ -5,13 +5,17 @@ module INITIAL-CHECKS
 // 1. A check for free variables
 
 
-// 2. A check for wildcards outside of patterns 
+// 2. A check for wildcards outside of patterns
 
 
 // 2. A check for unforgeable names
 
 
 // 3. Any normalization process that we want to do
+//      ---> probably want to change variable names, because of examples like
+//           for( @{{~{@{x}!(Nil)}}|x} <- @Nil ){ @{x}!("success") } | @Nil!(Nil|Nil)
+//           where the first x isn't binding, but the second x is. (Those two x's should
+//           be rewritten to different things -- the first being a dummy "variable".)
 
 
 

--- a/rho-syntax.k
+++ b/rho-syntax.k
@@ -20,8 +20,6 @@ syntax Proc ::=
               | ProcVar
               // The empty process
               | "Nil"
-              // SimpleType
-              | SimpleType
               // Variable reference
               > VarRef
               // Evaluate
@@ -278,6 +276,8 @@ syntax ProcPat ::=
                 "{" ProcPat "}" [bracket]
               // Collection pat
               | CollectionPat
+              // SimpleType
+              | SimpleType
               // logical negation
               > "~" ProcPat
               // logical "and"

--- a/rho-syntax.k
+++ b/rho-syntax.k
@@ -324,6 +324,9 @@ syntax SimpleType ::=
                 "Bool"
               | "Int"
               | "String"
+              | "List"
+              | "Tuple"
+              | "Map"
               | "Uri"
               | "ByteArray"
 

--- a/rho-syntax.k
+++ b/rho-syntax.k
@@ -274,20 +274,21 @@ syntax Procs ::=
 
 // Process Patterns
 syntax ProcPat ::=
-              // A process pattern can be a standard process
-                Proc
+              // Bracket
+                "{" ProcPat "}" [bracket]
               // Collection pat
               | CollectionPat
-              // Parallel
-              | ProcPat "|" ProcPat [left]
-              // Bracket
-              | "{" ProcPat "}" [bracket]
               // logical negation
               > "~" ProcPat
               // logical "and"
               > ProcPat "/\\" ProcPat [left]
               // logical "or"
               > ProcPat "\\/" ProcPat [left]
+              // A process pattern can be a standard process
+              > Proc
+              // Parallel
+              > ProcPat "|" ProcPat [left]
+
 
 syntax CollectionPat ::=
                 RhoListPat

--- a/rho-syntax.k
+++ b/rho-syntax.k
@@ -94,10 +94,8 @@ syntax RhoTuple ::=
 syntax RhoMap   ::= "{" RhoKeyValuePairs "}"
 
 syntax RhoKeyValuePairs ::=
-                RhoKeyValuePair
-              | RhoKeyValuePair "," RhoKeyValuePairs
-
-syntax RhoKeyValuePair  ::= Proc ":" Proc
+                Proc ":" Proc
+              | Proc ":" Proc "," RhoKeyValuePairs
 
 // Expressions are anything that necessarily resolves to a single ground value or a collection
 syntax Exp  ::=
@@ -163,17 +161,13 @@ syntax Receipt ::=
 
 // Linear receipts
 syntax LinearBinds ::=
-                LinearBind
-              | LinearBind ";" LinearBinds
-syntax LinearBind  ::=
                 NamePats "<-" Name
+              | NamePats "<-" Name ";" LinearBinds
 
 // Repeated receipts
 syntax RepeatedBinds ::=
-                RepeatedBind
-              | RepeatedBind ";" RepeatedBinds
-syntax RepeatedBind  ::=
                 NamePats "<=" Name
+              | NamePats "<=" Name ";" RepeatedBinds
 
 // MatchCase
 syntax MatchCase  ::= ProcPat "=>" "{" Proc "}" [binder]
@@ -182,10 +176,10 @@ syntax MatchCases ::=
               | MatchCase MatchCases
 
 // Branch
-syntax Branch   ::= LinearBinds "=>" Proc
 syntax Branches ::=
-                Branch
-              | Branch Branches
+              // Branch
+                LinearBinds "=>" Proc
+              | LinearBinds "=>" Proc Branches
 
 // Bundle
 syntax Bundle ::=

--- a/rho-syntax.k
+++ b/rho-syntax.k
@@ -160,9 +160,14 @@ syntax Receipt ::=
               | RepeatedBinds
 
 // Linear receipts
-syntax LinearBinds ::=
+syntax LinearBind  ::=
                 NamePats "<-" Name
-              | NamePats "<-" Name ";" LinearBinds
+              // Peeking
+              | NamePats "<!" Name
+
+syntax LinearBinds ::=
+                LinearBind
+              | LinearBind ";" LinearBinds
 
 // Repeated receipts
 syntax RepeatedBinds ::=

--- a/rho-syntax.k
+++ b/rho-syntax.k
@@ -158,13 +158,10 @@ syntax SendContent  ::=
 
 // Receipt
 syntax Receipt ::=
-                ReceiptLinear
-              | ReceiptRepeated
+                LinearBinds
+              | RepeatedBinds
 
 // Linear receipts
-syntax ReceiptLinear ::=
-                LinearBinds
-
 syntax LinearBinds ::=
                 LinearBind
               | LinearBind ";" LinearBinds
@@ -172,9 +169,6 @@ syntax LinearBind  ::=
                 NamePats "<-" Name
 
 // Repeated receipts
-syntax ReceiptRepeated ::=
-                RepeatedBinds
-
 syntax RepeatedBinds ::=
                 RepeatedBind
               | RepeatedBind ";" RepeatedBinds
@@ -188,7 +182,7 @@ syntax MatchCases ::=
               | MatchCase MatchCases
 
 // Branch
-syntax Branch   ::= ReceiptLinear "=>" Proc
+syntax Branch   ::= LinearBinds "=>" Proc
 syntax Branches ::=
                 Branch
               | Branch Branches

--- a/rho-syntax.k
+++ b/rho-syntax.k
@@ -20,6 +20,8 @@ syntax Proc ::=
               | ProcVar
               // The empty process
               | "Nil"
+              // SimpleType
+              | SimpleType
               // Variable reference
               > VarRef
               // Evaluate
@@ -51,39 +53,20 @@ syntax Proc ::=
               // Parallel
               > Proc "|" Proc [left]
 
-// Variables
-//syntax Wildcard ::= "_"
-syntax Var      ::=  Id
-syntax Vars     ::=
-                Var
-              | Var "," Vars
-              | Ids
-
-syntax Ids      ::=
-                Id
-              | Id "," Ids
-
 // Makes it so we _don't_ shadow the variable referenced
 syntax VarRef ::=
-                "="     ProcId
-              | "=" "*" NameId
+                "="     ProcVar
+              | "=" "*" NameVar
+
+// General variables
+syntax Var    ::= Id
+syntax Vars   ::= Var | Var "," Vars
 
 // Process variables
-syntax ProcVar ::=
-//                ProcWildcard
-              ProcId
-
-//syntax ProcWildcard ::= Wildcard
-syntax ProcId   ::= Id
-syntax ProcIds  ::=
-                ProcId
-              | ProcId "," ProcIds
-              | Ids
-
-syntax ProcVars ::=
+syntax ProcVar   ::= Var
+syntax ProcVars  ::=
                 ProcVar
               | ProcVar "," ProcVars
-              | ProcIds
               | Vars
 
 // Ground processes
@@ -254,20 +237,10 @@ syntax Name ::=
               | NameVar
 
 // Name variables
-syntax NameVar ::=
-//                NameWildcard
-              Id
-
-//syntax NameWildcard ::= Wildcard
-syntax NameId   ::= Id
-syntax NameIds  ::=
-                NameId
-              | NameId "," NameIds
-              | Ids
-syntax NameVars ::=
+syntax NameVar   ::= Var
+syntax NameVars  ::=
                 NameVar
               | NameVar "," NameVars
-              | NameIds
               | Vars
 
 // Name Declarations
@@ -355,8 +328,13 @@ syntax ProcPats ::=
 //    For K
 // -------------
 
-syntax KVariable ::= Id
-syntax KResult   ::= Bool | Int
+syntax KVariable  ::= Id | ProcVar | NameVar
+syntax KResult    ::= Bool | Int
 
+syntax SimpleType ::=
+                "Bool"
+              | "Int"
+              | "Uri"
+              | "ByteArray"
 
 endmodule

--- a/rho-syntax.k
+++ b/rho-syntax.k
@@ -329,6 +329,7 @@ syntax KResult    ::= Bool | Int
 syntax SimpleType ::=
                 "Bool"
               | "Int"
+              | "String"
               | "Uri"
               | "ByteArray"
 


### PR DESCRIPTION
Some more changes to conform to the BNFC, including simplification of variables and a simple type system.

Note: Variables can be simplified further if we don't want to distinguish between name and process variables. I think we should though -- name and process variables don't behave in the same way and the BNFC distinguishes between them.