### PR TITLE
Matching via an AST-based type system

### DIFF
--- a/normalizer.k
+++ b/normalizer.k
@@ -1,0 +1,10 @@
+module NORMALIZER
+
+// The normalizing algorithm, which is evaluated before executing the main program.
+
+// The normalizer:
+//     Renames variables for alpha equivalence
+//     Sorts parallel processes via a canonical sorting (like the current Rholang interpreter)
+
+
+endmodule

--- a/pattern-match.k
+++ b/pattern-match.k
@@ -1,0 +1,29 @@
+module PATTERN-MATCH
+imports TYPE
+
+// Matching Function
+syntax Match ::=
+              // Matching processes
+                "#patternMatch" Proc "#via" ProcPat "#in" Proc
+              // Matching names
+              | "#patternMatch" Name "#via" NamePat "#in" Proc
+
+// Matching by using types and the type inclusion predicate
+// if multiple match cases
+rule match P:Proc { P1:ProcPat => { P2:Proc } M:MatchCases }
+  => #if    #type( type[ P ] ) #isIn #type( type[ P1 ] )
+     #then  #patternMatch P #via P1 #in P2
+     #else  match P:Proc { M:MatchCases }
+     #fi
+
+// if a single match case
+rule match P:Proc { P1:ProcPat => { P2:Proc } }
+  => #if    #type( type[ P ] ) #isIn #type( type[ P1 ] )
+     #then  #patternMatch P #via P1 #in P2
+     #else  Nil
+     #fi
+
+// Temporary
+rule #patternMatch P:Proc #via P1:ProcPat #in P2:Proc => "success"
+
+endmodule

--- a/pattern-match.k
+++ b/pattern-match.k
@@ -1,6 +1,6 @@
 module PATTERN-MATCH
 imports TYPE
-
+/*
 // Matching Function
 syntax Match ::=
               // Matching processes
@@ -25,5 +25,5 @@ rule match P:Proc { P1:ProcPat => { P2:Proc } }
 
 // Temporary
 rule #patternMatch P:Proc #via P1:ProcPat #in P2:Proc => "success"
-
+*/
 endmodule

--- a/rho-syntax.k
+++ b/rho-syntax.k
@@ -312,7 +312,7 @@ syntax NamePat ::=
               | "@" ProcPat
 
 // Both Name and Process Patterns
-syntax Pat  ::=
+syntax Pat ::=
               // A name pattern
                 NamePat
               // A process pattern

--- a/rho-syntax.k
+++ b/rho-syntax.k
@@ -292,11 +292,11 @@ syntax CollectionPat ::=
 
 syntax RhoListPat ::=
                 RhoList
-              | "[" ProcPats "..." ProcVar "]"
+              | "[" ProcPats "," "..." ProcVar "]"
 
 syntax RhoSetPat ::=
                 RhoSet
-              | "Set" "(" ProcPats "..." ProcVar ")"
+              | "Set" "(" ProcPats "," "..." ProcVar ")"
 
 // Name Patterns
 syntax NamePat ::=

--- a/rho-syntax.k
+++ b/rho-syntax.k
@@ -53,8 +53,8 @@ syntax Proc ::=
 
 // Makes it so we _don't_ shadow the variable referenced
 syntax VarRef ::=
-                "="     ProcVar
-              | "=" "*" NameVar
+                "="     NameVar
+              | "=" "*" ProcVar
 
 // General variables
 syntax Var    ::= Id

--- a/rho-syntax.k
+++ b/rho-syntax.k
@@ -25,7 +25,7 @@ syntax Proc ::=
               // Evaluate
               > "*" Name
               // Method
-              > Proc "." Method "(" Procs ")"
+              > Proc "." Method "(" MethodArgs ")"
               // Arithmetic expressions
               > AExp
               // Boolean expressions
@@ -201,6 +201,12 @@ syntax Bundle ::=
               | "bundle"
 
 // Methods
+syntax MethodArgs ::=
+              // There is either a list of processes for args
+                Procs
+              // Or there is nothing
+              | ""
+
 syntax Method ::=
               // The list of current methods (add as more methods are defined)
                 "method(nth)"

--- a/rho-syntax.k
+++ b/rho-syntax.k
@@ -171,8 +171,11 @@ syntax LinearBinds ::=
 
 // Repeated receipts
 syntax RepeatedBinds ::=
+                RepeatedBind
+              | RepeatedBind ";" RepeatedBinds
+
+syntax RepeatedBind  ::=
                 NamePats "<=" Name
-              | NamePats "<=" Name ";" RepeatedBinds
 
 // MatchCase
 syntax MatchCase  ::= ProcPat "=>" "{" Proc "}" [binder]
@@ -289,11 +292,11 @@ syntax CollectionPat ::=
 
 syntax RhoListPat ::=
                 RhoList
-              | "[" Procs "..." ProcVar "]"
+              | "[" ProcPats "..." ProcVar "]"
 
 syntax RhoSetPat ::=
                 RhoSet
-              | "Set" "(" Procs "..." ProcVar ")"
+              | "Set" "(" ProcPats "..." ProcVar ")"
 
 // Name Patterns
 syntax NamePat ::=
@@ -303,7 +306,7 @@ syntax NamePat ::=
               | "@" ProcPat
 
 // Both Name and Process Patterns
-syntax Pat ::=
+syntax Pat  ::=
               // A name pattern
                 NamePat
               // A process pattern
@@ -313,6 +316,7 @@ syntax NamePats ::=
                 NamePat
               | NamePat "," NamePats
               | Names
+
 syntax ProcPats ::=
                 ProcPat
               | ProcPat "," ProcPats

--- a/rho-syntax.k
+++ b/rho-syntax.k
@@ -53,8 +53,8 @@ syntax Proc ::=
 
 // Makes it so we _don't_ shadow the variable referenced
 syntax VarRef ::=
-                "="     NameVar
-              | "=" "*" ProcVar
+                "="     ProcVar
+              | "=" "*" NameVar
 
 // General variables
 syntax Var    ::= Id

--- a/rho-syntax.k
+++ b/rho-syntax.k
@@ -178,7 +178,7 @@ syntax RepeatedBind  ::=
                 NamePats "<=" Name
 
 // MatchCase
-syntax MatchCase  ::= ProcPat "=>" "{" Proc "}" [binder]
+syntax MatchCase  ::= ProcPat "=>" Proc [binder]
 syntax MatchCases ::=
                 MatchCase
               | MatchCase MatchCases

--- a/rho-syntax.k
+++ b/rho-syntax.k
@@ -36,8 +36,6 @@ syntax Proc ::=
               > "contract" Name "(" NamePats ")" "=" "{" Proc "}"
               // Listen
               | "for" "(" Receipt ")" "{" Proc "}" [binder]
-              // Select
-              | "select" "{" Branches "}"
               // Match
               | "match" Proc "{" MatchCases "}"
               // Bundle
@@ -182,12 +180,6 @@ syntax MatchCase  ::= ProcPat "=>" Proc [binder]
 syntax MatchCases ::=
                 MatchCase
               | MatchCase MatchCases
-
-// Branch
-syntax Branches ::=
-              // Branch
-                LinearBinds "=>" Proc
-              | LinearBinds "=>" Proc Branches
 
 // Bundle
 syntax Bundle ::=

--- a/rho.k
+++ b/rho.k
@@ -1,6 +1,9 @@
 require "rho-syntax.k"
 require "configuration.k"
 require "initial-checks.k"
+require "normalizer.k"
+require "type.k"
+require "pattern-match.k"
 
 module RHO
 imports DOMAINS
@@ -8,5 +11,8 @@ imports DOMAINS
 imports RHO-SYNTAX
 imports CONFIGURATION
 imports INITIAL-CHECKS
+imports NORMALIZER
+imports TYPE
+imports PATTERN-MATCH
 
 endmodule

--- a/type.k
+++ b/type.k
@@ -29,22 +29,157 @@ syntax Leaf             ::= Ground | Var | NameVar | ProcVar
 syntax KResult ::= TerminalType
 
 // Rewrite rules to generate types
-rule type[ Chan:Name!(Msg:Proc) ] => type[ "send"  ;; type[Chan] ;; type[Msg] ]
-rule type[ Chan:Name!!(Msg:Proc)] => type[ "psend" ;; type[Chan] ;; type[Msg] ]
-rule type[ @P:Proc ]              => type[ "quote" ;; type["#@"] ;; type[P]   ]
-rule type[ L:Leaf  ]              => type[ "leaf"  ;; "#leaf"    ;; L         ]
+
+// *** Process types ***
+// Ground terms
+rule type[ I:Int                ] => [ "int"         ;; I ]
+rule type[ S:String             ] => [ "string"      ;; S ]
+rule type[ U:Uri                ] => [ "uri"         ;; U ]
+rule type[ unforgeable( I:Int ) ] => [ "unforgeable" ;; I ]
+
+// Boolean expressions
+rule type[ true                    ] => type[ "bool"         ;; true     ]
+rule type[ false                   ] => type[ "bool"         ;; false    ]
+rule type[ not B:Bool              ] => type[ "boolnot"      ;; type[B]  ]
+rule type[ I1:Int  <       I2:Int  ] => type[ "bool<"        ;; I1 ;; I2 ]
+rule type[ I1:Int  >       I2:Int  ] => type[ "bool>"        ;; I1 ;; I2 ]
+rule type[ I1:Int  <=      I2:Int  ] => type[ "bool<="       ;; I1 ;; I2 ]
+rule type[ I1:Int  >=      I2:Int  ] => type[ "bool>="       ;; I1 ;; I2 ]
+rule type[ P1:Proc matches P2:Proc ] => type[ "boolmatches"  ;; P1 ;; P2 ]
+rule type[ P1:Proc ==      P2:Proc ] => type[ "bool=="       ;; P1 ;; P2 ]
+rule type[ P1:Proc !=      P2:Proc ] => type[ "bool!="       ;; P1 ;; P2 ]
+rule type[ B1:Bool and     B2:Bool ] => type[ "booland"      ;; type[B1] ;; type[B2] ]
+rule type[ B1:Bool or      B2:Bool ] => type[ "boolor"       ;; type[B1] ;; type[B2] ]
+
+// Collection
+//   RhoList
+rule type[ [ Hd:Proc Tl:Procs ] ] => [ "list" ;; type[ Hd ] ;; type[ [Tl] ] ]
+rule type[ [ Sng:Proc         ] ] => [ "list" ;; type[Sng]                  ]
+
+//   RhoTuple
+rule type[ ( Hd:Proc Md:Proc Tl:Procs ) ] => [ "tuple" ;; type[Hd] ;; type[ (Md,Tl) ] ]
+rule type[ ( Hd:Proc Tl:Proc          ) ] => [ "tuple" ;; type[Hd] ;; type[ ( Tl ,) ] ]
+rule type[ ( Sng:Proc                ,) ] => [ "tuple" ;; type[Sng]                   ]
+
+//   RhoSet
+rule type[ Set( Hd:Proc Tl:Procs ) ] => [ "set" ;; type[Hd] ;; type[ Set(Tl) ] ]
+rule type[ Set( Sng:Proc )         ] => [ "set" ;; type[Sng]                   ]
+
+//   RhoMap
+rule type[{ Hd:RhoKeyValuePair , Tl:RhoKeyValuePairs }] => [ "map" ;; type[ {Hd} ] ;; type[{Tl}] ]
+rule type[{ Key:Proc : Val:Proc                      }] => [ "map" ;; type[Key]    ;; type[Val]  ]
+
+// Process variables
+rule type[ PV:ProcVar ] => type[ "procvar" ;; PV ]
+
+// The empty process
+rule type[ Nil ] => type[ "nil" ;; Nil ]
+
+// Variable reference
+rule type[ =  PV:ProcVar ] => type[ "varref" ;; type[PV] ]
+rule type[ =* NV:NameVar ] => type[ "varref" ;; type[NV] ]
+
+// Evaluate
+rule type[ * N:Name ] => type[ "eval" ;; type[Name] ]
+
+// Method
+rule type[ P:Proc . M:Method ( PS:Procs ) ] => [ toString(M) ;; P ;; PS ]
+
+// Arithmetic expressions
+rule type[ I1:Int *  I2:Int ] => type[ "mult"       ;; I1 ;; I2 ]
+rule type[ I1:Int /  I2:Int ] => type[ "div"        ;; I1 ;; I2 ]
+rule type[ I1:Int %% I2:Int ] => type[ "mod"        ;; I1 ;; I2 ]
+rule type[ I1:Int +  I2:Int ] => type[ "plus"       ;; I1 ;; I2 ]
+rule type[ I1:Int -  I2:Int ] => type[ "minus"      ;; I1 ;; I2 ]
+rule type[ I1:Int ++ I2:Int ] => type[ "plusplus"   ;; I1 ;; I2 ]
+rule type[ I1:Int -- I2:Int ] => type[ "minusminus" ;; I1 ;; I2 ]
+
+
+// Send
+rule type[ Chan:Name!  Msg:Send ] => type[ "send"  ;; type[Chan] ;; type[Msg] ]
+rule type[ Chan:Name!! Msg:Send ] => type[ "psend" ;; type[Chan] ;; type[Msg] ]
+
+// Contract **needs to be given an alias which binds**
+rule type[ contract Chan:Name ( Patns:NamePats ) = { Body:Proc } ] =>
+             type[ "contract" ;; type[ "bind" ;; type[ Patns ] ;; type[ Body ] ] ;; type[ Chan ] ]
+// Listen
+rule type[ for( LB:LinearBinds   ){ Body:Proc } ] => type[ "listen"  ;; type[ LB ] ;; type[ Body ] ]
+rule type[ for( RB:RepeatedBinds ){ Body:Proc } ] => type[ "plisten" ;; type[ RB ] ;; type[ Body ] ]
+
+rule type[ Hd:LinearBind ; Tl:LinearBinds ] => type[ "linearbinds" ;; type[Hd]    ;; type[Tl]   ]
+rule type[ Patns:NamePats <- Chan:Name  ]   => type[ "listen"      ;; type[Patns] ;; type[Name] ]
+rule type[ Patns:NamePats <! Chan:Name  ]   => type[ "peek"        ;; type[Patns] ;; type[Name] ]
+
+rule type[ Patns:NamePats <= Chan:Name ; RBs:RepeatedBinds ]
+                  => type[ "repeatedbinds" ;; type[Patns <= Chan] ;; type[Rbs] ]
+rule type[ Patns:NamePats <= Chan:Name ] => type[ "plisten" ;; type[Patns] ;; type[Chan] ]
+
+// Name Patterns
+rule type[ Hd:NamePat , Tl:NamePats ] => type[ "namepats" ;; type[Hd] ;; type[Tl] ]
+
+// Match
+rule type[ match P:Proc { MC:MatchCases } ] => type[ "match" ;; type[P] ;; type[MC] ]
+
+rule type[ Hd:MatchCase Tl:MatchCases    ] => type[ "matchcases" ;; type[Hd]   ;; type[Tl]   ]
+rule type[ Patn:ProcPat => { Body:Proc } ] => type[ "matchcase"  ;; type[Patn] ;; type[Body] ]
+
+// Bundle
+rule type[ bundle+ { P:Proc } ] => type[ "bundle+" ;; type[P] ]
+rule type[ bundle- { P:Proc } ] => type[ "bundle-" ;; type[P] ]
+rule type[ bundle0 { P:Proc } ] => type[ "bundle0" ;; type[P] ]
+rule type[ bundle  { P:Proc } ] => type[ "bundle"  ;; type[P] ]
+
+// If ... then ...
+rule type[ if ( B:Bool ) P:Proc ] => type[ "if" ;; type[B] ;; type[P] ]
+
+// If ... then ... else ...
+rule type[ if ( B:Bool ) PTrue:Proc else PFalse:Proc ]
+              => type[ "ifelse" ;; type[B] ;; type["ifelseprocs" ;; type[PTrue] ;; type[PFalse] ] ]
+
+// New
+rule type[ new N:NameDeclarations in { Body:Proc} ] => type[ "new" ;; type[N] ;; type[Body] ]
+
+rule type[ Hd:NameDeclaration Tl:NameDeclarations ]
+                              => type[ "namedeclarations" ;; type[Hd] ;; type[Tl] ]
+rule type[ NV:NameVar ( U:Uri ) ] => type[ "urinamedeclaration" ;; type[NV] ;; type[U] ]
+
+// Parallel
+rule type[ P1:ProcPat | P2:ProcPat ] => type[ "par" ;; type[P1] ;; type[P2] ]
+
+// *** Name types ***
+rule type[ @P:Proc    ] => type[ "quote"   ;; type[P] ]
+rule type[ NV:NameVar ] => type[ "namevar" ;; NV      ]
+
+// *** Pattern types ***
+// Collection pat
+//   RhoListPat
+rule type[ [Hd:Procs    ... Tl:ProcVar] ] => type[ "rholistpat" ;; type[Hd] ;; type[Tl] ]
+//   RhoSetPat
+rule type[ Set(Hd:Procs ... Tl:ProcVar) ] => type[ "rhosetpat"  ;; type[Hd] ;; type[Tl] ]
+
+// SimpleType
+rule type[ ST:SimpleType ] => type[ "simpletype" ;; toString(ST) ]
+
+// logical negation
+rule type[ ~ PPat:ProcPat ] => type[ "logicalnegate" ;; type[PPat] ]
+
+// logical "and"
+rule type[ PPat1:ProcPat /\ PPat2:ProcPat ] => type[ "logicaland" ;; PPat1 ;; PPat2]
+
+// logical "or"
+rule type[ PPat1:ProcPat \/ PPat2:ProcPat ] => type[ "logicalor"  ;; PPat1 ;; PPat2]
+
+
 
 // Type( ) is strict, and rewrites as the type.
-rule #type( T:TerminalType ) => T
+rule #type( T:TerminalType ) => T [strict]
+
 
 
 
 // Type inclusion predicate
 // The function #isIn is the inclusion predicate
 syntax Bool ::= Type "#isIn" Type [function]
-
-
-rule T1:Type #isIn T2:Type => true
 
 
 

--- a/type.k
+++ b/type.k
@@ -42,8 +42,6 @@ syntax KResult ::= TerminalType
 
 // Type( ) is strict, and rewrites as the type.
 rule #type( T:Type ) => T [strict]
-rule TYPE( P:Proc ) => #type( type[P] )
-rule TYPE( N:Name ) => #type( type[N] )
 
 // Rewrite rules to generate types
 

--- a/type.k
+++ b/type.k
@@ -1,0 +1,51 @@
+module TYPE
+imports RHO-SYNTAX
+
+// Syntax for the type system.
+syntax Type ::=
+              // A function that rewrites to the type of the input
+                "#type(" Type ")"
+              // Initializing syntax
+              | InitialType
+              // Intermediate syntax
+              | IntermediateType
+              // Terminal syntax
+              | TerminalType
+
+// Recursive syntax for the type rewrites
+syntax InitialType      ::= "type[" Pat "]" | "type[" Leaf "]"
+syntax IntermediateType ::=
+                            "type[" String ";;" InitialType      ";;" InitialType      "]" [strict(2,3)]
+                          | "type[" String ";;" IntermediateType ";;" IntermediateType "]" [strict(3)]
+                          | TerminalType
+
+syntax TerminalType     ::=
+                            "type[" String ";;" Leaf             ";;" Leaf             "]"
+                          | "type[" String ";;" TerminalType     ";;" TerminalType     "]"
+
+syntax Leaf             ::= Ground | Var | NameVar | ProcVar
+
+// Syntax for strictness
+syntax KResult ::= TerminalType
+
+// Rewrite rules to generate types
+rule type[ Chan:Name!(Msg:Proc) ] => type[ "send"  ;; type[Chan] ;; type[Msg] ]
+rule type[ Chan:Name!!(Msg:Proc)] => type[ "psend" ;; type[Chan] ;; type[Msg] ]
+rule type[ @P:Proc ]              => type[ "quote" ;; type["#@"] ;; type[P]   ]
+rule type[ L:Leaf  ]              => type[ "leaf"  ;; "#leaf"    ;; L         ]
+
+// Type( ) is strict, and rewrites as the type.
+rule #type( T:TerminalType ) => T
+
+
+
+// Type inclusion predicate
+// The function #isIn is the inclusion predicate
+syntax Bool ::= Type "#isIn" Type [function]
+
+
+rule T1:Type #isIn T2:Type => true
+
+
+
+endmodule

--- a/type.k
+++ b/type.k
@@ -104,6 +104,7 @@ rule type[ P:Proc . M:Method ( Hd:Proc , Tl:Procs ) ]
                      => type[ "method" ;; type[Hd] ;; type[P:Proc . M:Method ( Tl:Procs )] ]
 
 rule type[ P:Proc . M:Method ( Hd:Proc ) ] => type[ toString( M ) ;; type[P] ;; type[Hd] ]
+rule type[ P:Proc . M:Method () ] => type[ toString( M ) ;; type[P] ;; type[#truncate] ]
 
 // Arithmetic expressions
 rule type[ I1:Int *  I2:Int ] => type[ "mult"       ;; type[I1] ;; type[I2] ]
@@ -143,7 +144,7 @@ rule type[ Hd:NamePat , Tl:NamePats ] => type[ "namepats" ;; type[Hd] ;; type[Tl
 rule type[ match P:Proc { MC:MatchCases } ] => type[ "match"      ;; type[P]    ;; type[MC]   ]
 
 rule type[ Hd:MatchCase Tl:MatchCases    ]  => type[ "matchcases" ;; type[Hd]   ;; type[Tl]   ]
-//rule type[ Patn:ProcPat => { Body:Proc } ]  => type[ "matchcase"  ;; type[Patn] ;; type[Body] ]
+rule type[ (Patn => { Body }):MatchCase  ]  => type[ "matchcase"  ;; type[Patn] ;; type[Body] ]
 
 // Bundle
 rule type[ bundle+ { P:Proc } ] => type[ "bundle+" ;; type[P] ;; type[#truncate] ]
@@ -175,16 +176,16 @@ rule type[ NV:NameVar ] => type[ "leaf"  ;; "namevar" ;; NV              ]
 // *** Pattern types ***
 // Collection pat
 //   RhoListPat Multiple
-rule type[ [Hd1:Proc, Hd:Procs    ... Tl:ProcVar] ]
-                    => type[ "rholistpathead" ;; type[Hd1] ;; type[[Hd:Procs    ... Tl:ProcVar]] ]
+rule type[ [Hd1:ProcPat, Hd:ProcPats,   ... Tl:ProcVar] ]
+                    => type[ "rholistpathead" ;; type[Hd1] ;; type[[Hd,    ... Tl]] ]
 //   RhoListPat Single
-rule type[ [Hd:Proc    ... Tl:ProcVar] ] => type[ "rholistpat" ;; type[Hd] ;; type[Tl] ]
+rule type[ [Hd:ProcPat,    ... Tl:ProcVar] ] => type[ "rholistpat" ;; type[Hd] ;; type[Tl] ]
 
 //   RhoSetPat Multiple
-rule type[ Set(Hd1:Proc, Hd:Procs ... Tl:ProcVar) ]
-                    => type[ "rhosetpathead"  ;; type[Hd1] ;; type[Set(Hd:Procs ... Tl:ProcVar)] ]
+rule type[ Set(Hd1:ProcPat, Hd:ProcPats, ... Tl:ProcVar) ]
+                    => type[ "rhosetpathead"  ;; type[Hd1] ;; type[Set(Hd, ... Tl)] ]
 //   RhoSetPat Single
-rule type[ Set(Hd:Proc ... Tl:ProcVar) ] => type[ "rhosetpat"  ;; type[Hd] ;; type[Tl] ]
+rule type[ Set(Hd:ProcPat, ... Tl:ProcVar) ] => type[ "rhosetpat"  ;; type[Hd] ;; type[Tl] ]
 
 // SimpleType
 rule type[ ST:SimpleType ]  => type[ "simpletype"    ;; type[toString(ST)] ;; type[#truncate] ]

--- a/type.k
+++ b/type.k
@@ -1,5 +1,7 @@
 module TYPE
 imports RHO-SYNTAX
+// The structural type system, based on ASTs.
+
 
 // Syntax for the type system.
 syntax Type ::=
@@ -13,174 +15,192 @@ syntax Type ::=
               | TerminalType
 
 // Recursive syntax for the type rewrites
-syntax InitialType      ::= "type[" Pat "]" | "type[" Leaf "]"
+syntax InitialType      ::= "type[" Pat              "]"
+                          | "type[" Leaf             "]"
+                          | "type[" RepeatedBinds    "]"
+                          | "type[" LinearBinds      "]"
+                          | "type[" NamePats         "]"
+                          | "type[" NameDeclarations "]"
+                          | "type[" MatchCases       "]"
+
 syntax IntermediateType ::=
-                            "type[" String ";;" InitialType      ";;" InitialType      "]" [strict(2,3)]
-                          | "type[" String ";;" IntermediateType ";;" IntermediateType "]" [strict(3)]
+                            "type[" String ";;" IntermediateType ";;" IntermediateType "]" [strict(2,3)]
                           | TerminalType
+                          | InitialType
 
 syntax TerminalType     ::=
                             "type[" String ";;" Leaf             ";;" Leaf             "]"
                           | "type[" String ";;" TerminalType     ";;" TerminalType     "]"
 
-syntax Leaf             ::= Ground | Var | NameVar | ProcVar
+
+syntax Leaf             ::= Ground | Var | NameVar | ProcVar | "#truncate"
+syntax String           ::= "toString(" Pat ")" | "toString(" Method ")"
 
 // Syntax for strictness
 syntax KResult ::= TerminalType
+
+
+// Type( ) is strict, and rewrites as the type.
+rule #type( T:Type ) => T [strict]
+rule TYPE( P:Proc ) => #type( type[P] )
+rule TYPE( N:Name ) => #type( type[N] )
 
 // Rewrite rules to generate types
 
 // *** Process types ***
 // Ground terms
-rule type[ I:Int                ] => [ "int"         ;; I ]
-rule type[ S:String             ] => [ "string"      ;; S ]
-rule type[ U:Uri                ] => [ "uri"         ;; U ]
-rule type[ unforgeable( I:Int ) ] => [ "unforgeable" ;; I ]
+rule type[ I:Int                ] => type[ "leaf" ;; "int"         ;; I ]
+rule type[ S:String             ] => type[ "leaf" ;; "string"      ;; S ]
+rule type[ uri( S:String )      ] => type[ "leaf" ;; "uri"         ;; S ]
+rule type[ unforgeable( I:Int ) ] => type[ "leaf" ;; "unforgeable" ;; I ]
 
 // Boolean expressions
-rule type[ true                    ] => type[ "bool"         ;; true     ]
-rule type[ false                   ] => type[ "bool"         ;; false    ]
-rule type[ not B:Bool              ] => type[ "boolnot"      ;; type[B]  ]
-rule type[ I1:Int  <       I2:Int  ] => type[ "bool<"        ;; I1 ;; I2 ]
-rule type[ I1:Int  >       I2:Int  ] => type[ "bool>"        ;; I1 ;; I2 ]
-rule type[ I1:Int  <=      I2:Int  ] => type[ "bool<="       ;; I1 ;; I2 ]
-rule type[ I1:Int  >=      I2:Int  ] => type[ "bool>="       ;; I1 ;; I2 ]
-rule type[ P1:Proc matches P2:Proc ] => type[ "boolmatches"  ;; P1 ;; P2 ]
-rule type[ P1:Proc ==      P2:Proc ] => type[ "bool=="       ;; P1 ;; P2 ]
-rule type[ P1:Proc !=      P2:Proc ] => type[ "bool!="       ;; P1 ;; P2 ]
-rule type[ B1:Bool and     B2:Bool ] => type[ "booland"      ;; type[B1] ;; type[B2] ]
-rule type[ B1:Bool or      B2:Bool ] => type[ "boolor"       ;; type[B1] ;; type[B2] ]
+rule type[ true                    ] => type[ "leaf"         ;; "bool"    ;; true            ]
+rule type[ false                   ] => type[ "leaf"         ;; "bool"    ;; false           ]
+rule type[ not B:Bool              ] => type[ "boolnot"      ;; type[B]   ;; type[#truncate] ]
+rule type[ I1:Int  <       I2:Int  ] => type[ "bool<"        ;; type[I1]  ;; type[I2]        ]
+rule type[ I1:Int  >       I2:Int  ] => type[ "bool>"        ;; type[I1]  ;; type[I2]        ]
+rule type[ I1:Int  <=      I2:Int  ] => type[ "bool<="       ;; type[I1]  ;; type[I2]        ]
+rule type[ I1:Int  >=      I2:Int  ] => type[ "bool>="       ;; type[I1]  ;; type[I2]        ]
+rule type[ P1:Proc matches P2:Proc ] => type[ "boolmatches"  ;; type[P1]  ;; type[P2]        ]
+rule type[ P1:Proc ==      P2:Proc ] => type[ "bool=="       ;; type[P1]  ;; type[P2]        ]
+rule type[ P1:Proc !=      P2:Proc ] => type[ "bool!="       ;; type[P1]  ;; type[P2]        ]
+rule type[ B1:Bool and     B2:Bool ] => type[ "booland"      ;; type[B1]  ;; type[B2]        ]
+rule type[ B1:Bool or      B2:Bool ] => type[ "boolor"       ;; type[B1]  ;; type[B2]        ]
 
 // Collection
 //   RhoList
-rule type[ [ Hd:Proc Tl:Procs ] ] => [ "list" ;; type[ Hd ] ;; type[ [Tl] ] ]
-rule type[ [ Sng:Proc         ] ] => [ "list" ;; type[Sng]                  ]
+rule type[ [ Hd:Proc , Tl:Procs ] ] => type[ "list" ;; type[ Hd ] ;; type[ [Tl] ]    ]
+rule type[ [ Sng:Proc           ] ] => type[ "list" ;; type[Sng]  ;; type[#truncate] ]
 
 //   RhoTuple
-rule type[ ( Hd:Proc Md:Proc Tl:Procs ) ] => [ "tuple" ;; type[Hd] ;; type[ (Md,Tl) ] ]
-rule type[ ( Hd:Proc Tl:Proc          ) ] => [ "tuple" ;; type[Hd] ;; type[ ( Tl ,) ] ]
-rule type[ ( Sng:Proc                ,) ] => [ "tuple" ;; type[Sng]                   ]
+rule type[ ( Hd:Proc , Md:Proc , Tl:Procs ) ] => type[ "tuple" ;; type[Hd]  ;; type[ (Md,Tl) ] ]
+rule type[ ( Hd:Proc , Tl:Proc            ) ] => type[ "tuple" ;; type[Hd]  ;; type[ ( Tl ,) ] ]
+rule type[ ( Sng:Proc                    ,) ] => type[ "tuple" ;; type[Sng] ;; type[#truncate] ]
 
 //   RhoSet
-rule type[ Set( Hd:Proc Tl:Procs ) ] => [ "set" ;; type[Hd] ;; type[ Set(Tl) ] ]
-rule type[ Set( Sng:Proc )         ] => [ "set" ;; type[Sng]                   ]
+rule type[ Set( Hd:Proc , Tl:Procs ) ] => type[ "set" ;; type[Hd]  ;; type[ Set(Tl) ] ]
+rule type[ Set( Sng:Proc   )         ] => type[ "set" ;; type[Sng] ;; type[#truncate] ]
 
 //   RhoMap
-rule type[{ Hd:RhoKeyValuePair , Tl:RhoKeyValuePairs }] => [ "map" ;; type[ {Hd} ] ;; type[{Tl}] ]
-rule type[{ Key:Proc : Val:Proc                      }] => [ "map" ;; type[Key]    ;; type[Val]  ]
+rule type[{Hd:RhoKeyValuePair , Tl:RhoKeyValuePairs}] => type[ "map" ;; type[{Hd}] ;; type[{Tl}] ]
+rule type[{Key:Proc : Val:Proc                     }] => type[ "map" ;; type[Key]  ;; type[Val]  ]
 
 // Process variables
-rule type[ PV:ProcVar ] => type[ "procvar" ;; PV ]
+rule type[ PV:ProcVar ] => type[ "leaf" ;; "procvar" ;; PV ]
 
 // The empty process
-rule type[ Nil ] => type[ "nil" ;; Nil ]
+rule type[ Nil ] => type[ "leaf" ;; "nil" ;; "Nil" ]
 
 // Variable reference
-rule type[ =  PV:ProcVar ] => type[ "varref" ;; type[PV] ]
-rule type[ =* NV:NameVar ] => type[ "varref" ;; type[NV] ]
+rule type[ =  PV:ProcVar ] => type[ "varref" ;; type[PV] ;; type[#truncate] ]
+rule type[ =* NV:NameVar ] => type[ "varref" ;; type[NV] ;; type[#truncate] ]
 
 // Evaluate
-rule type[ * N:Name ] => type[ "eval" ;; type[Name] ]
+rule type[ * N:Name ] => type[ "eval" ;; type[N] ;; type[#truncate] ]
 
 // Method
-rule type[ P:Proc . M:Method ( PS:Procs ) ] => [ toString(M) ;; P ;; PS ]
+rule type[ P:Proc . M:Method ( Hd:Proc , Tl:Procs ) ]
+                     => type[ "method" ;; type[Hd] ;; type[P:Proc . M:Method ( Tl:Procs )] ]
+
+rule type[ P:Proc . M:Method ( Hd:Proc ) ] => type[ toString( M ) ;; type[P] ;; type[Hd] ]
 
 // Arithmetic expressions
-rule type[ I1:Int *  I2:Int ] => type[ "mult"       ;; I1 ;; I2 ]
-rule type[ I1:Int /  I2:Int ] => type[ "div"        ;; I1 ;; I2 ]
-rule type[ I1:Int %% I2:Int ] => type[ "mod"        ;; I1 ;; I2 ]
-rule type[ I1:Int +  I2:Int ] => type[ "plus"       ;; I1 ;; I2 ]
-rule type[ I1:Int -  I2:Int ] => type[ "minus"      ;; I1 ;; I2 ]
-rule type[ I1:Int ++ I2:Int ] => type[ "plusplus"   ;; I1 ;; I2 ]
-rule type[ I1:Int -- I2:Int ] => type[ "minusminus" ;; I1 ;; I2 ]
+rule type[ I1:Int *  I2:Int ] => type[ "mult"       ;; type[I1] ;; type[I2] ]
+rule type[ I1:Int /  I2:Int ] => type[ "div"        ;; type[I1] ;; type[I2] ]
+rule type[ I1:Int %% I2:Int ] => type[ "mod"        ;; type[I1] ;; type[I2] ]
+rule type[ I1:Int +  I2:Int ] => type[ "plus"       ;; type[I1] ;; type[I2] ]
+rule type[ I1:Int -  I2:Int ] => type[ "minus"      ;; type[I1] ;; type[I2] ]
+rule type[ I1:Int ++ I2:Int ] => type[ "plusplus"   ;; type[I1] ;; type[I2] ]
+rule type[ I1:Int -- I2:Int ] => type[ "minusminus" ;; type[I1] ;; type[I2] ]
 
 
 // Send
-rule type[ Chan:Name!  Msg:Send ] => type[ "send"  ;; type[Chan] ;; type[Msg] ]
-rule type[ Chan:Name!! Msg:Send ] => type[ "psend" ;; type[Chan] ;; type[Msg] ]
+rule type[ Chan:Name!  (Msg:Proc)   ] => type[ "send"  ;; type[Chan] ;; type[Msg] ]
+rule type[ Chan:Name!  Msg:RhoTuple ] => type[ "send"  ;; type[Chan] ;; type[Msg] ]
+rule type[ Chan:Name!! (Msg:Proc)   ] => type[ "psend" ;; type[Chan] ;; type[Msg] ]
+rule type[ Chan:Name!! Msg:RhoTuple ] => type[ "psend" ;; type[Chan] ;; type[Msg] ]
 
 // Contract **needs to be given an alias which binds**
 rule type[ contract Chan:Name ( Patns:NamePats ) = { Body:Proc } ] =>
-             type[ "contract" ;; type[ "bind" ;; type[ Patns ] ;; type[ Body ] ] ;; type[ Chan ] ]
+           type[ "contract" ;; type[ Patns <= Chan ] ;; type[ Body ] ]
 // Listen
 rule type[ for( LB:LinearBinds   ){ Body:Proc } ] => type[ "listen"  ;; type[ LB ] ;; type[ Body ] ]
 rule type[ for( RB:RepeatedBinds ){ Body:Proc } ] => type[ "plisten" ;; type[ RB ] ;; type[ Body ] ]
 
 rule type[ Hd:LinearBind ; Tl:LinearBinds ] => type[ "linearbinds" ;; type[Hd]    ;; type[Tl]   ]
-rule type[ Patns:NamePats <- Chan:Name  ]   => type[ "listen"      ;; type[Patns] ;; type[Name] ]
-rule type[ Patns:NamePats <! Chan:Name  ]   => type[ "peek"        ;; type[Patns] ;; type[Name] ]
+rule type[ Patns:NamePats <- Chan:Name    ] => type[ "listen"      ;; type[Patns] ;; type[Chan] ]
+rule type[ Patns:NamePats <! Chan:Name    ] => type[ "peek"        ;; type[Patns] ;; type[Chan] ]
 
-rule type[ Patns:NamePats <= Chan:Name ; RBs:RepeatedBinds ]
-                  => type[ "repeatedbinds" ;; type[Patns <= Chan] ;; type[Rbs] ]
+rule type[ RB:RepeatedBind ; RBs:RepeatedBinds ]
+                  => type[ "repeatedbinds" ;; type[RB] ;; type[RBs] ]
 rule type[ Patns:NamePats <= Chan:Name ] => type[ "plisten" ;; type[Patns] ;; type[Chan] ]
 
 // Name Patterns
 rule type[ Hd:NamePat , Tl:NamePats ] => type[ "namepats" ;; type[Hd] ;; type[Tl] ]
 
 // Match
-rule type[ match P:Proc { MC:MatchCases } ] => type[ "match" ;; type[P] ;; type[MC] ]
+rule type[ match P:Proc { MC:MatchCases } ] => type[ "match"      ;; type[P]    ;; type[MC]   ]
 
-rule type[ Hd:MatchCase Tl:MatchCases    ] => type[ "matchcases" ;; type[Hd]   ;; type[Tl]   ]
-rule type[ Patn:ProcPat => { Body:Proc } ] => type[ "matchcase"  ;; type[Patn] ;; type[Body] ]
+rule type[ Hd:MatchCase Tl:MatchCases    ]  => type[ "matchcases" ;; type[Hd]   ;; type[Tl]   ]
+//rule type[ Patn:ProcPat => { Body:Proc } ]  => type[ "matchcase"  ;; type[Patn] ;; type[Body] ]
 
 // Bundle
-rule type[ bundle+ { P:Proc } ] => type[ "bundle+" ;; type[P] ]
-rule type[ bundle- { P:Proc } ] => type[ "bundle-" ;; type[P] ]
-rule type[ bundle0 { P:Proc } ] => type[ "bundle0" ;; type[P] ]
-rule type[ bundle  { P:Proc } ] => type[ "bundle"  ;; type[P] ]
+rule type[ bundle+ { P:Proc } ] => type[ "bundle+" ;; type[P] ;; type[#truncate] ]
+rule type[ bundle- { P:Proc } ] => type[ "bundle-" ;; type[P] ;; type[#truncate] ]
+rule type[ bundle0 { P:Proc } ] => type[ "bundle0" ;; type[P] ;; type[#truncate] ]
+rule type[ bundle  { P:Proc } ] => type[ "bundle"  ;; type[P] ;; type[#truncate] ]
 
 // If ... then ...
 rule type[ if ( B:Bool ) P:Proc ] => type[ "if" ;; type[B] ;; type[P] ]
 
 // If ... then ... else ...
 rule type[ if ( B:Bool ) PTrue:Proc else PFalse:Proc ]
-              => type[ "ifelse" ;; type[B] ;; type["ifelseprocs" ;; type[PTrue] ;; type[PFalse] ] ]
+              => type[ "ifelse" ;; type[B] ;; type[ "ifelseprocs" ;; type[PTrue] ;; type[PFalse] ] ]
 
 // New
 rule type[ new N:NameDeclarations in { Body:Proc} ] => type[ "new" ;; type[N] ;; type[Body] ]
 
-rule type[ Hd:NameDeclaration Tl:NameDeclarations ]
-                              => type[ "namedeclarations" ;; type[Hd] ;; type[Tl] ]
-rule type[ NV:NameVar ( U:Uri ) ] => type[ "urinamedeclaration" ;; type[NV] ;; type[U] ]
+rule type[ Hd:NameDeclaration, Tl:NameDeclarations ]
+                                  => type[ "namedeclarations"   ;; type[Hd] ;; type[Tl] ]
+rule type[ NV:NameVar ( U:Uri ) ] => type[ "urinamedeclaration" ;; type[NV] ;; type[U]  ]
 
 // Parallel
 rule type[ P1:ProcPat | P2:ProcPat ] => type[ "par" ;; type[P1] ;; type[P2] ]
 
 // *** Name types ***
-rule type[ @P:Proc    ] => type[ "quote"   ;; type[P] ]
-rule type[ NV:NameVar ] => type[ "namevar" ;; NV      ]
+rule type[ @P:Proc    ] => type[ "quote" ;; type[P]   ;; type[#truncate] ]
+rule type[ NV:NameVar ] => type[ "leaf"  ;; "namevar" ;; NV              ]
 
 // *** Pattern types ***
 // Collection pat
-//   RhoListPat
-rule type[ [Hd:Procs    ... Tl:ProcVar] ] => type[ "rholistpat" ;; type[Hd] ;; type[Tl] ]
-//   RhoSetPat
-rule type[ Set(Hd:Procs ... Tl:ProcVar) ] => type[ "rhosetpat"  ;; type[Hd] ;; type[Tl] ]
+//   RhoListPat Multiple
+rule type[ [Hd1:Proc, Hd:Procs    ... Tl:ProcVar] ]
+                    => type[ "rholistpathead" ;; type[Hd1] ;; type[[Hd:Procs    ... Tl:ProcVar]] ]
+//   RhoListPat Single
+rule type[ [Hd:Proc    ... Tl:ProcVar] ] => type[ "rholistpat" ;; type[Hd] ;; type[Tl] ]
+
+//   RhoSetPat Multiple
+rule type[ Set(Hd1:Proc, Hd:Procs ... Tl:ProcVar) ]
+                    => type[ "rhosetpathead"  ;; type[Hd1] ;; type[Set(Hd:Procs ... Tl:ProcVar)] ]
+//   RhoSetPat Single
+rule type[ Set(Hd:Proc ... Tl:ProcVar) ] => type[ "rhosetpat"  ;; type[Hd] ;; type[Tl] ]
 
 // SimpleType
-rule type[ ST:SimpleType ] => type[ "simpletype" ;; toString(ST) ]
+rule type[ ST:SimpleType ]  => type[ "simpletype"    ;; type[toString(ST)] ;; type[#truncate] ]
 
 // logical negation
-rule type[ ~ PPat:ProcPat ] => type[ "logicalnegate" ;; type[PPat] ]
+rule type[ ~ PPat:ProcPat ] => type[ "logicalnegate" ;; type[PPat]         ;; type[#truncate] ]
 
 // logical "and"
-rule type[ PPat1:ProcPat /\ PPat2:ProcPat ] => type[ "logicaland" ;; PPat1 ;; PPat2]
+rule type[ PPat1:ProcPat /\ PPat2:ProcPat ] => type[ "logicaland" ;; type[PPat1] ;; type[PPat2] ]
 
 // logical "or"
-rule type[ PPat1:ProcPat \/ PPat2:ProcPat ] => type[ "logicalor"  ;; PPat1 ;; PPat2]
+rule type[ PPat1:ProcPat \/ PPat2:ProcPat ] => type[ "logicalor"  ;; type[PPat1] ;; type[PPat2] ]
 
+// *** Misc ***
 
-
-// Type( ) is strict, and rewrites as the type.
-rule #type( T:TerminalType ) => T [strict]
-
-
-
-
-// Type inclusion predicate
-// The function #isIn is the inclusion predicate
-syntax Bool ::= Type "#isIn" Type [function]
-
-
+// #truncate
+rule type[ #truncate ] => type[ "leaf" ;; "truncate" ;; #truncate ]
 
 endmodule


### PR DESCRIPTION
After the normalizer has sorted parallel processes via a canonical sorting and renamed variables to solve alpha equivalence, processes and names can be matched by using ASTs. In type.k, we introduce notation for the AST that will be easy for K to work with. In pattern-match.k, we show how the type system would be incorporated into a matching algorithm, vastly simpler than the one currently on rchain/rchain.